### PR TITLE
Add caret to dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "node": ">=8.9"
   },
   "dependencies": {
-    "react": "16.6.0",
-    "react-is": "16.6.0"
+    "react": "^16.6.0",
+    "react-is": "^16.6.0"
   },
   "devDependencies": {
     "@babel/cli": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-children-addons",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "React Children Addons",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
Hey Birkir,

als already mentioned in the Issue #1 this little change makes it possible to use your package when the used react version has a different minor/patch version.